### PR TITLE
README.md acorde con archivo docker-compose.yml

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -24,17 +24,10 @@ define('WP_REDIS_DATABASE', 0);
 
 Por otro lado, recordarte, que además tienes un ejecutable `wpcli` que te permitirá trabajar directamente con WordPress desde la línea de comandos.
 
-A la hora de levantar el servicio dependerá del proxy inverso que hayas seleccionado. Si has elegido Caddy, simplemente,
+A la hora de levantar el servicio, en esta ocasión optamos por Traefik como proxy inverso. Si has elegido Caddy, habrá que modificar los parámetros del archivo `docker-compose.yml`:
 
 ```
-docker-compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
-docker-compose logs -f
-```
-
-Mientras que si has elegido Traefik,
-
-```
-docker-compose -f docker-compose.yml -f docker-compose.traefik.yml up -d
+docker-compose -f docker-compose.yml up -d
 docker-compose logs -f
 ```
 


### PR DESCRIPTION
En el `README.md` de la carpeta `wordpress` figuran las instrucciones que hacen referencia a unos archivos que no existen en la carpeta, `docker-compose-traefik.yml` y `docker-compose-caddy.yml`.
Tras mi "issue" #10 me dí cuenta que la configuración para levantar el servicio con Traefik está incluida en el mismo archivo principal `docker-compose.yml` y lo he corregido en el `README.md`