### PR TITLE
downgrade db container postgres version to 15

### DIFF
--- a/miniflux/docker-compose.yml
+++ b/miniflux/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     env_file:
       - .env
   db:
-    image: postgres:latest
+    image: postgres:15
     init: true
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
Due to Postgres update to v16, breaks the miniflux_db container. Changed tag image from "latest" to "15" resolves.